### PR TITLE
Node restructure

### DIFF
--- a/turtlebot4_msgs/CMakeLists.txt
+++ b/turtlebot4_msgs/CMakeLists.txt
@@ -29,6 +29,7 @@ find_package(std_msgs REQUIRED)
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/UserLed.msg"
   "msg/UserButton.msg"
+  "msg/UserDisplay.msg"
 )
 
 ament_package()

--- a/turtlebot4_msgs/msg/UserDisplay.msg
+++ b/turtlebot4_msgs/msg/UserDisplay.msg
@@ -1,0 +1,7 @@
+# This message represents the header and 5 entries 
+# that are displayed on the Turtlebot4 display
+# selected_entry indicates which menu entry is currently selected
+
+string header
+string[5] entries
+int32 selected_entry

--- a/turtlebot4_msgs/msg/UserDisplay.msg
+++ b/turtlebot4_msgs/msg/UserDisplay.msg
@@ -2,6 +2,7 @@
 # that are displayed on the Turtlebot4 display
 # selected_entry indicates which menu entry is currently selected
 
-string header
+string ip
+string battery
 string[5] entries
 int32 selected_entry

--- a/turtlebot4_node/CMakeLists.txt
+++ b/turtlebot4_node/CMakeLists.txt
@@ -61,6 +61,10 @@ install(TARGETS ${EXECUTABLE_NAME}
   DESTINATION lib/${PROJECT_NAME}
 )
 
+install(
+  DIRECTORY include
+)
+
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   list(APPEND AMENT_LINT_AUTO_EXCLUDE

--- a/turtlebot4_node/CMakeLists.txt
+++ b/turtlebot4_node/CMakeLists.txt
@@ -25,8 +25,6 @@ find_package(sensor_msgs REQUIRED)
 find_package(irobot_create_msgs REQUIRED)
 find_package(turtlebot4_msgs REQUIRED)
 
-find_library(GPIOD_LIBRARY NAMES libgpiod.so)
-
 #Build
 
 include_directories(

--- a/turtlebot4_node/CMakeLists.txt
+++ b/turtlebot4_node/CMakeLists.txt
@@ -1,0 +1,78 @@
+cmake_minimum_required(VERSION 3.5)
+project(turtlebot4_node)
+
+# Default to C99
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 99)
+endif()
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_action REQUIRED)
+find_package(rcutils REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(irobot_create_msgs REQUIRED)
+find_package(turtlebot4_msgs REQUIRED)
+
+find_library(GPIOD_LIBRARY NAMES libgpiod.so)
+
+#Build
+
+include_directories(
+  include
+)
+
+add_library(${PROJECT_NAME}_lib
+  "src/main.cpp"
+  "src/turtlebot4.cpp"
+  "src/display.cpp"
+  "src/buttons.cpp"
+  "src/leds.cpp"
+)
+
+set(DEPENDENCIES
+  "rclcpp"
+  "rclcpp_action"
+  "rcutils"
+  "std_msgs"
+  "sensor_msgs"
+  "irobot_create_msgs"
+  "turtlebot4_msgs"
+)
+
+target_link_libraries(${PROJECT_NAME}_lib ${GPIOD_LIBRARY})
+
+ament_target_dependencies(${PROJECT_NAME}_lib ${DEPENDENCIES})
+
+set(EXECUTABLE_NAME "turtlebot4_node")
+
+add_executable(${EXECUTABLE_NAME} src/main.cpp)
+target_link_libraries(${EXECUTABLE_NAME} ${PROJECT_NAME}_lib)
+ament_target_dependencies(${EXECUTABLE_NAME} ${DEPENDENCIES})
+
+install(TARGETS ${EXECUTABLE_NAME}
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  list(APPEND AMENT_LINT_AUTO_EXCLUDE
+    ament_cmake_copyright
+  )
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+
+ament_export_include_directories(include)
+ament_package()

--- a/turtlebot4_node/CMakeLists.txt
+++ b/turtlebot4_node/CMakeLists.txt
@@ -49,8 +49,6 @@ set(DEPENDENCIES
   "turtlebot4_msgs"
 )
 
-target_link_libraries(${PROJECT_NAME}_lib ${GPIOD_LIBRARY})
-
 ament_target_dependencies(${PROJECT_NAME}_lib ${DEPENDENCIES})
 
 set(EXECUTABLE_NAME "turtlebot4_node")

--- a/turtlebot4_node/include/turtlebot4_node/action.hpp
+++ b/turtlebot4_node/include/turtlebot4_node/action.hpp
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2021 Clearpath Robotics, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Roni Kreinin (rkreinin@clearpathrobotics.com)
+ */
+
+#ifndef TURTLEBOT4_NODE__ACTION_HPP_
+#define TURTLEBOT4_NODE__ACTION_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+#include <memory>
+#include <string>
+#include "rclcpp_action/rclcpp_action.hpp"
+
+
+namespace turtlebot4
+{
+// Templated Action class to allow any ROS actions to be used
+template<typename ActionT>
+class Turtlebot4Action
+{
+public:
+  // Constructor and Destructor
+  explicit Turtlebot4Action(std::shared_ptr<rclcpp::Node> & nh, std::string action)
+  : nh_(nh), action_(action)
+  {
+    // Create action client
+    client_ = rclcpp_action::create_client<ActionT>(nh_, action);
+  }
+  virtual ~Turtlebot4Action() {}
+
+  void send_goal()
+  {
+    RCLCPP_INFO(nh_->get_logger(), "Waiting for %s action server", action_.c_str());
+
+    // Cancel existing timers
+    if (timer_ != nullptr) {
+      timer_->cancel();
+    }
+
+    // Create timer to check for service without blocking
+    timer_ = nh_->create_wall_timer(
+      std::chrono::milliseconds(1000),
+      [this]() -> void
+      {
+        // Wait for action server
+        if (client_->wait_for_action_server(std::chrono::milliseconds(10))) {
+          RCLCPP_INFO(
+            nh_->get_logger(), "%s action server available, sending goal",
+            action_.c_str());
+          timer_->cancel();
+
+          // Create goal
+          auto goal_msg = typename ActionT::Goal();
+
+          // Set goal callbacks
+          auto send_goal_options = typename rclcpp_action::Client<ActionT>::SendGoalOptions();
+          send_goal_options.goal_response_callback =
+          std::bind(&Turtlebot4Action::goal_response_callback, this, std::placeholders::_1);
+          send_goal_options.feedback_callback =
+          std::bind(
+            &Turtlebot4Action::feedback_callback, this, std::placeholders::_1,
+            std::placeholders::_2);
+          send_goal_options.result_callback =
+          std::bind(&Turtlebot4Action::result_callback, this, std::placeholders::_1);
+
+          // Send goal
+          this->client_->async_send_goal(goal_msg, send_goal_options);
+        } else {
+          // TODO(roni-kreinin): Add timeout
+        }
+      });
+  }
+
+private:
+  // Node handle
+  std::shared_ptr<rclcpp::Node> nh_;
+  // Action
+  std::string action_;
+  // Timer
+  rclcpp::TimerBase::SharedPtr timer_;
+  // Action client
+  typename rclcpp_action::Client<ActionT>::SharedPtr client_;
+
+  // TODO(roni-kreinin): Virtual callbacks?
+
+  /**
+    * @brief Goal response callback
+    * @input future - Shared future with goal response
+    */
+  void goal_response_callback(
+    std::shared_future<typename rclcpp_action::ClientGoalHandle<ActionT>::SharedPtr> future)
+  {
+    auto goal_handle = future.get();
+    if (!goal_handle) {
+      RCLCPP_ERROR(nh_->get_logger(), "%s goal was rejected by server", action_.c_str());
+    } else {
+      RCLCPP_INFO(
+        nh_->get_logger(), "%s goal accepted by server, waiting for result",
+        action_.c_str());
+    }
+  }
+
+  /**
+    * @brief Feedback callback
+    * @input ptr - Unused
+    * @input feedback - Action feedback
+    */
+  void feedback_callback(
+    typename rclcpp_action::ClientGoalHandle<ActionT>::SharedPtr ptr,
+    const std::shared_ptr<const typename ActionT::Feedback> feedback)
+  {
+    (void)ptr;
+    (void)feedback;
+  }
+
+  /**
+    * @brief Result callback
+    * @input result - Action result
+    */
+  void result_callback(
+    const typename rclcpp_action::ClientGoalHandle<ActionT>::WrappedResult & result)
+  {
+    switch (result.code) {
+      case rclcpp_action::ResultCode::SUCCEEDED:
+        RCLCPP_INFO(nh_->get_logger(), "%s goal succeeded", action_.c_str());
+        break;
+      case rclcpp_action::ResultCode::ABORTED:
+        RCLCPP_ERROR(nh_->get_logger(), "%s goal was aborted", action_.c_str());
+        return;
+      case rclcpp_action::ResultCode::CANCELED:
+        RCLCPP_ERROR(nh_->get_logger(), "%s goal was canceled", action_.c_str());
+        return;
+      default:
+        RCLCPP_ERROR(nh_->get_logger(), "%s Unknown result code", action_.c_str());
+        return;
+    }
+  }
+};
+
+}  // namespace turtlebot4
+
+#endif  // TURTLEBOT4_NODE__ACTION_HPP_

--- a/turtlebot4_node/include/turtlebot4_node/buttons.hpp
+++ b/turtlebot4_node/include/turtlebot4_node/buttons.hpp
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2021 Clearpath Robotics, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Roni Kreinin (rkreinin@clearpathrobotics.com)
+ */
+
+#ifndef TURTLEBOT4_NODE__BUTTONS_HPP_
+#define TURTLEBOT4_NODE__BUTTONS_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/int32.hpp>
+
+#include <string>
+#include <vector>
+#include <memory>
+
+#include "irobot_create_msgs/msg/interface_buttons.hpp"
+#include "turtlebot4_msgs/msg/user_button.hpp"
+#include "turtlebot4_node/utils.hpp"
+
+
+namespace turtlebot4
+{
+
+enum Turtlebot4ButtonEnum
+{
+  CREATE3_1,
+  CREATE3_POWER,
+  CREATE3_2,
+  HMI_1,
+  HMI_2,
+  HMI_3,
+  HMI_4,
+};
+
+enum Turtlebot4ButtonState
+{
+  RELEASED = 0,
+  PRESSED = 1,
+  WAIT_FOR_RELEASE
+};
+
+struct Turtlebot4Button
+{
+  Turtlebot4ButtonEnum button_;
+
+  std::string short_function_;
+  turtlebot4_function_callback_t short_cb_;
+  std::string long_function_;
+  turtlebot4_function_callback_t long_cb_;
+
+  int long_press_duration_ms_;
+  std::chrono::time_point<std::chrono::steady_clock> last_start_pressed_time_;
+
+  Turtlebot4ButtonState current_state_;
+  Turtlebot4ButtonState next_state_;
+
+  Turtlebot4Button(Turtlebot4ButtonEnum button, std::vector<std::string> params)
+  : button_(button),
+    current_state_(RELEASED),
+    next_state_(RELEASED)
+  {
+    short_function_ = params.at(0);
+    long_function_ = params.at(1);
+    long_press_duration_ms_ = params.at(2).empty() ? 0 : std::stoi(params.at(2));
+  }
+
+  void set_state(Turtlebot4ButtonState state)
+  {
+    next_state_ = state;
+  }
+
+  void spin_once()
+  {
+    switch (current_state_) {
+      case RELEASED:
+        {
+          if (next_state_ == PRESSED) {
+            // Start timer
+            last_start_pressed_time_ = std::chrono::steady_clock::now();
+            current_state_ = PRESSED;
+          }
+          break;
+        }
+
+      case PRESSED:
+        {
+          if (next_state_ == PRESSED) {
+            // Long press implemented
+            if (long_press_duration_ms_ > 0) {
+              if (std::chrono::steady_clock::now() >
+                last_start_pressed_time_ + std::chrono::milliseconds(long_press_duration_ms_))
+              {
+                long_press();
+                current_state_ = WAIT_FOR_RELEASE;
+              }
+            } else {
+              // Long press not implemented, do short press function and wait for release
+              short_press();
+              current_state_ = WAIT_FOR_RELEASE;
+            }
+          } else if (next_state_ == RELEASED) {
+            short_press();
+            current_state_ = RELEASED;
+          }
+          break;
+        }
+
+      case WAIT_FOR_RELEASE:
+        {
+          if (next_state_ == RELEASED) {
+            current_state_ = RELEASED;
+          }
+          break;
+        }
+
+      default:
+        break;
+    }
+  }
+
+  void short_press()
+  {
+    if (short_cb_ != nullptr) {
+      short_cb_();
+    }
+  }
+
+  void long_press()
+  {
+    if (long_cb_ != nullptr) {
+      long_cb_();
+    }
+  }
+};
+
+class Buttons
+{
+public:
+  Buttons(
+    Turtlebot4Model model,
+    std::vector<Turtlebot4Button> buttons,
+    std::shared_ptr<rclcpp::Node> & nh);
+
+  void spin_once();
+
+private:
+  void create3_buttons_callback(
+    const irobot_create_msgs::msg::InterfaceButtons::SharedPtr create3_buttons_msg);
+  void hmi_buttons_callback(const turtlebot4_msgs::msg::UserButton::SharedPtr hmi_buttons_msg);
+  
+  Turtlebot4Model model_;
+
+  std::vector<Turtlebot4Button> buttons_;
+
+  std::shared_ptr<rclcpp::Node> nh_;
+  rclcpp::Subscription<irobot_create_msgs::msg::InterfaceButtons>::SharedPtr create3_buttons_sub_;
+  rclcpp::Subscription<turtlebot4_msgs::msg::UserButton>::SharedPtr hmi_buttons_sub_;
+};
+
+}  // namespace turtlebot4
+
+#endif  // TURTLEBOT4_NODE__BUTTONS_HPP_

--- a/turtlebot4_node/include/turtlebot4_node/buttons.hpp
+++ b/turtlebot4_node/include/turtlebot4_node/buttons.hpp
@@ -57,8 +57,8 @@ struct Turtlebot4Button
   Turtlebot4ButtonEnum button_;
 
   std::string short_function_;
-  turtlebot4_function_callback_t short_cb_;
   std::string long_function_;
+  turtlebot4_function_callback_t short_cb_;
   turtlebot4_function_callback_t long_cb_;
 
   int long_press_duration_ms_;

--- a/turtlebot4_node/include/turtlebot4_node/display.hpp
+++ b/turtlebot4_node/include/turtlebot4_node/display.hpp
@@ -35,9 +35,9 @@
 namespace turtlebot4
 {
 
-#define DISPLAY_NUM_LINES 5
-#define DISPLAY_CHAR_PER_LINE 18
-#define DISPLAY_CHAR_PER_LINE_HEADER 21
+static constexpr auto DISPLAY_NUM_LINES = 5;
+static constexpr auto DISPLAY_CHAR_PER_LINE = 18;
+static constexpr auto DISPLAY_CHAR_PER_LINE_HEADER = 21;
 
 struct Turtlebot4MenuEntry
 {

--- a/turtlebot4_node/include/turtlebot4_node/display.hpp
+++ b/turtlebot4_node/include/turtlebot4_node/display.hpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2021 Clearpath Robotics, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Roni Kreinin (rkreinin@clearpathrobotics.com)
+ */
+
+#ifndef TURTLEBOT4_NODE__DISPLAY_HPP_
+#define TURTLEBOT4_NODE__DISPLAY_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/battery_state.hpp>
+#include <std_msgs/msg/string.hpp>
+#include <std_msgs/msg/int32.hpp>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "turtlebot4_node/utils.hpp"
+#include "turtlebot4_msgs/msg/user_display.hpp"
+
+
+namespace turtlebot4
+{
+
+#define DISPLAY_NUM_LINES 5
+#define DISPLAY_CHAR_PER_LINE 18
+#define DISPLAY_CHAR_PER_LINE_HEADER 21
+
+struct Turtlebot4MenuEntry
+{
+  std::string name_;
+  turtlebot4_function_callback_t cb_;
+
+  explicit Turtlebot4MenuEntry(std::string name)
+  : name_(name)
+  {}
+};
+
+class Display
+{
+public:
+  // Constructor and Destructor
+  explicit Display(
+    std::vector<Turtlebot4MenuEntry> entries,
+    std::shared_ptr<rclcpp::Node> & nh);
+  virtual ~Display() {}
+
+  // Setters
+  void set_battery(const sensor_msgs::msg::BatteryState::SharedPtr & battery_state_msg);
+  void set_ip(std::string ip);
+
+  // Menu Navigation
+  void scroll_up();
+  void scroll_down();
+  void select();
+  void back();
+  void show_message(std::vector<std::string> message);
+  void show_message(std::string message);
+
+  // Spin Once
+  void spin_once();
+
+private:
+  // Update display
+  void update();
+  void update_header();
+  void set_menu_entries();
+  void pad_line(std::string & line);
+  std::vector<Turtlebot4MenuEntry> get_visible_entries();
+
+  void display_message_callback(const std_msgs::msg::String::SharedPtr display_msg);
+
+  // Node handle
+  std::shared_ptr<rclcpp::Node> nh_;
+  rclcpp::Publisher<turtlebot4_msgs::msg::UserDisplay>::SharedPtr display_pub_;
+  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr display_message_sub_;
+
+  // Menu
+  std::vector<Turtlebot4MenuEntry> menu_entries_;
+  std::vector<Turtlebot4MenuEntry> visible_entries_;
+  std::vector<std::string> display_lines_;
+  bool menu_override_;
+  uint8_t scroll_position_;
+  uint8_t selected_line_;
+
+  // Header
+  std::string ip_;
+  int battery_percentage_;
+  std::string header_;
+};
+
+}  // namespace turtlebot4
+
+#endif  // TURTLEBOT4_NODE__DISPLAY_HPP_

--- a/turtlebot4_node/include/turtlebot4_node/leds.hpp
+++ b/turtlebot4_node/include/turtlebot4_node/leds.hpp
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2021 Clearpath Robotics, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Roni Kreinin (rkreinin@clearpathrobotics.com)
+ */
+
+#ifndef TURTLEBOT4_NODE__LEDS_HPP_
+#define TURTLEBOT4_NODE__LEDS_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+#include <chrono>
+#include <map>
+#include <memory>
+#include <string>
+
+#include "turtlebot4_msgs/msg/user_led.hpp"
+#include "turtlebot4_node/utils.hpp"
+
+#include "std_msgs/msg/int32.hpp"
+
+namespace turtlebot4
+{
+
+enum Turtlebot4LedEnum
+{
+  POWER,
+  MOTORS,
+  COMMS,
+  WIFI,
+  BATTERY,
+  USER_1,
+  USER_2,
+  COUNT
+};
+
+enum Turtlebot4LedType
+{
+  GREEN_ONLY,
+  RED_GREEN
+};
+
+enum Turtlebot4LedColor
+{
+  OFF = 0,
+  GREEN = 1,
+  RED = 2,
+  YELLOW = 3
+};
+
+struct Turtlebot4Led
+{
+  Turtlebot4LedType type_;
+  uint32_t on_period_ms_, off_period_ms_;
+  std::chrono::time_point<std::chrono::steady_clock> last_on_time_, last_off_time_;
+  Turtlebot4LedColor current_color_, next_color_, blink_color_;
+  rclcpp::Publisher<std_msgs::msg::Int32>::SharedPtr led_pub_;
+
+  Turtlebot4Led(Turtlebot4LedType type)
+  : type_(type),
+    on_period_ms_(0),
+    off_period_ms_(1000),
+    current_color_(Turtlebot4LedColor::OFF),
+    next_color_(Turtlebot4LedColor::OFF),
+    blink_color_(Turtlebot4LedColor::OFF)
+  {}
+
+  void create_publisher(rclcpp::Node::SharedPtr nh, std::string topic)
+  {
+    led_pub_ = nh->create_publisher<std_msgs::msg::Int32>(topic, rclcpp::SensorDataQoS());
+  }
+
+  void spin_once()
+  {
+    switch (current_color_) {
+      case Turtlebot4LedColor::OFF:
+        {
+          // Duty cycle > 0
+          if (on_period_ms_ > 0) {
+            // Time to turn on
+            if (std::chrono::steady_clock::now() >
+              last_off_time_ + std::chrono::milliseconds(off_period_ms_))
+            {
+              last_on_time_ = std::chrono::steady_clock::now();
+              current_color_ = blink_color_;
+            }
+          }
+          break;
+        }
+
+      case Turtlebot4LedColor::GREEN:
+      case Turtlebot4LedColor::RED:
+      case Turtlebot4LedColor::YELLOW:
+        {
+          // Duty cycle < 1.0 or blink color is OFF
+          if (off_period_ms_ > 0 || blink_color_ != current_color_) {
+            // Time to blink off
+            if (std::chrono::steady_clock::now() >
+              last_on_time_ + std::chrono::milliseconds(on_period_ms_))
+            {
+              last_off_time_ = std::chrono::steady_clock::now();
+              current_color_ = Turtlebot4LedColor::OFF;
+            }
+          }
+          break;
+        }
+
+      default:
+        {
+          return;
+        }
+    }
+
+    auto msg = std_msgs::msg::Int32();
+    msg.data = static_cast<int32_t>(current_color_);
+    led_pub_->publish(msg);
+  }
+};
+
+class Leds
+{
+public:
+  Leds(
+    std::shared_ptr<rclcpp::Node> & nh);
+
+  void spin_once();
+  void set_led(Turtlebot4LedEnum led, Turtlebot4LedColor color);
+  void blink(
+    Turtlebot4LedEnum led, uint32_t blink_period_ms, double duty_cycle,
+    Turtlebot4LedColor color);
+
+private:
+  void user_led_callback(const turtlebot4_msgs::msg::UserLed user_led_msg);
+
+  std::shared_ptr<rclcpp::Node> nh_;
+
+  rclcpp::Subscription<turtlebot4_msgs::msg::UserLed>::SharedPtr user_led_sub_;
+
+  std::map<Turtlebot4LedEnum, std::shared_ptr<Turtlebot4Led>> leds_;
+};
+
+}  // namespace turtlebot4
+
+#endif  // TURTLEBOT4_NODE__LEDS_HPP_

--- a/turtlebot4_node/include/turtlebot4_node/leds.hpp
+++ b/turtlebot4_node/include/turtlebot4_node/leds.hpp
@@ -33,32 +33,6 @@
 namespace turtlebot4
 {
 
-enum Turtlebot4LedEnum
-{
-  POWER,
-  MOTORS,
-  COMMS,
-  WIFI,
-  BATTERY,
-  USER_1,
-  USER_2,
-  COUNT
-};
-
-enum Turtlebot4LedType
-{
-  GREEN_ONLY,
-  RED_GREEN
-};
-
-enum Turtlebot4LedColor
-{
-  OFF = 0,
-  GREEN = 1,
-  RED = 2,
-  YELLOW = 3
-};
-
 struct Turtlebot4Led
 {
   Turtlebot4LedType type_;

--- a/turtlebot4_node/include/turtlebot4_node/leds.hpp
+++ b/turtlebot4_node/include/turtlebot4_node/leds.hpp
@@ -78,7 +78,7 @@ struct Turtlebot4Led
 
   void create_publisher(rclcpp::Node::SharedPtr nh, std::string topic)
   {
-    led_pub_ = nh->create_publisher<std_msgs::msg::Int32>(topic, rclcpp::SensorDataQoS());
+    led_pub_ = nh->create_publisher<std_msgs::msg::Int32>(topic, rclcpp::QoS(rclcpp::KeepLast(10)));
   }
 
   void spin_once()

--- a/turtlebot4_node/include/turtlebot4_node/service.hpp
+++ b/turtlebot4_node/include/turtlebot4_node/service.hpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2021 Clearpath Robotics, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Roni Kreinin (rkreinin@clearpathrobotics.com)
+ */
+
+#ifndef TURTLEBOT4_NODE__SERVICE_HPP_
+#define TURTLEBOT4_NODE__SERVICE_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+#include <memory>
+#include <future>
+#include <string>
+
+namespace turtlebot4
+{
+// Templated Service class to allow any ROS services to be used
+template<typename ServiceT>
+class Turtlebot4Service
+{
+public:
+  // Constructor and Destructor
+  explicit Turtlebot4Service(std::shared_ptr<rclcpp::Node> & nh, std::string service)
+  : nh_(nh), service_(service)
+  {
+    // Create service client
+    client_ = nh_->create_client<ServiceT>(service);
+  }
+  virtual ~Turtlebot4Service() {}
+
+  void make_request(std::shared_ptr<typename ServiceT::Request> request)
+  {
+    request_ = request;
+
+    // Cancel existing timers
+    if (timer_ != nullptr) {
+      timer_->cancel();
+    }
+
+    // Create timer to check for service without blocking
+    timer_ = nh_->create_wall_timer(
+      std::chrono::milliseconds(1000),
+      [this]() -> void
+      {
+        // Check for service
+        if (client_->wait_for_service(std::chrono::milliseconds(10))) {
+          RCLCPP_INFO(nh_->get_logger(), "%s service available, sending request", service_.c_str());
+          timer_->cancel();
+
+          // Send request
+          auto future_result = client_->async_send_request(
+            request_,
+            std::bind(&Turtlebot4Service::response_callback, this, std::placeholders::_1));
+        } else if (!rclcpp::ok()) {
+          RCLCPP_ERROR(
+            nh_->get_logger(), "Interrupted while waiting for the service %s.",
+            service_.c_str());
+          timer_->cancel();
+        } else {
+          // TODO(roni-kreinin): Add timeout
+        }
+      });
+  }
+
+private:
+  // Node handle
+  std::shared_ptr<rclcpp::Node> nh_;
+  // Service
+  std::string service_;
+  // Timer
+  rclcpp::TimerBase::SharedPtr timer_;
+  // Service client
+  typename rclcpp::Client<ServiceT>::SharedPtr client_;
+  // Service request
+  std::shared_ptr<typename ServiceT::Request> request_;
+
+  // TODO(roni-kreinin): Virtual callback?
+  // Service response callback
+  void response_callback(typename rclcpp::Client<ServiceT>::SharedFuture future)
+  {
+    auto result = future.get();
+    RCLCPP_INFO(
+      nh_->get_logger(), "%s service got results: %s",
+      service_.c_str(), result->success ? "Success" : "Failed");
+    RCLCPP_INFO(nh_->get_logger(), result->message.c_str());
+  }
+};
+
+}  // namespace turtlebot4
+
+#endif  // TURTLEBOT4_NODE__SERVICE_HPP_

--- a/turtlebot4_node/include/turtlebot4_node/turtlebot4.hpp
+++ b/turtlebot4_node/include/turtlebot4_node/turtlebot4.hpp
@@ -80,7 +80,8 @@ private:
   // Function callbacks
   void dock_function_callback();
   void undock_function_callback();
-  void follow_function_callback();
+  void wall_follow_left_function_callback();
+  void wall_follow_right_function_callback();
   void estop_function_callback();
   void power_function_callback();
   void scroll_up_function_callback();

--- a/turtlebot4_node/include/turtlebot4_node/turtlebot4.hpp
+++ b/turtlebot4_node/include/turtlebot4_node/turtlebot4.hpp
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2021 Clearpath Robotics, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Roni Kreinin (rkreinin@clearpathrobotics.com)
+ */
+
+#ifndef TURTLEBOT4_NODE__TURTLEBOT4_HPP_
+#define TURTLEBOT4_NODE__TURTLEBOT4_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/battery_state.hpp>
+#include <std_msgs/msg/string.hpp>
+
+#include <chrono>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "turtlebot4_node/action.hpp"
+#include "turtlebot4_node/service.hpp"
+#include "turtlebot4_node/display.hpp"
+#include "turtlebot4_node/buttons.hpp"
+#include "turtlebot4_node/leds.hpp"
+#include "turtlebot4_node/utils.hpp"
+
+#include "irobot_create_msgs/msg/wheel_status.hpp"
+#include "irobot_create_msgs/action/undock.hpp"
+#include "irobot_create_msgs/action/dock_servo.hpp"
+#include "irobot_create_msgs/action/wall_follow.hpp"
+#include "irobot_create_msgs/srv/e_stop.hpp"
+#include "irobot_create_msgs/srv/robot_power.hpp"
+
+
+/** Supported functions
+ * Dock
+ * Undock
+ * Follow
+ * Power off
+ * EStop
+ */
+
+namespace turtlebot4
+{
+
+class Turtlebot4 : public rclcpp::Node
+{
+public:
+  // Type alias for actions and services
+  using Dock = irobot_create_msgs::action::DockServo;
+  using Undock = irobot_create_msgs::action::Undock;
+  using WallFollow = irobot_create_msgs::action::WallFollow;
+  using EStop = irobot_create_msgs::srv::EStop;
+  using Power = irobot_create_msgs::srv::RobotPower;
+
+  // Constructor and Destructor
+  explicit Turtlebot4();
+  virtual ~Turtlebot4() {}
+
+private:
+  void run();
+
+  // Subscription callbacks
+  void battery_callback(const sensor_msgs::msg::BatteryState::SharedPtr battery_state_msg);
+  void wheel_status_callback(
+    const irobot_create_msgs::msg::WheelStatus::SharedPtr wheel_status_msg);
+
+  // Function callbacks
+  void dock_function_callback();
+  void undock_function_callback();
+  void follow_function_callback();
+  void estop_function_callback();
+  void power_function_callback();
+  void scroll_up_function_callback();
+  void scroll_down_function_callback();
+  void select_function_callback();
+  void back_function_callback();
+  void help_function_callback();
+  void unused_function_callback();
+
+  void add_button_function_callbacks();
+  void add_menu_function_callbacks();
+
+  // Run display timer
+  void display_timer(const std::chrono::milliseconds timeout);
+
+  // Run buttons timer
+  void buttons_timer(const std::chrono::milliseconds timeout);
+
+  // Run leds timer
+  void leds_timer(const std::chrono::milliseconds timeout);
+
+  // Run wifi timer
+  void wifi_timer(const std::chrono::milliseconds timeout);
+
+  // Run comms timer
+  void comms_timer(const std::chrono::milliseconds timeout);
+
+  // IP
+  std::string get_ip();
+  std::string wifi_interface_;
+
+  // Node
+  rclcpp::Node::SharedPtr node_handle_;
+
+  // Turtlebot4 Functions
+  std::vector<Turtlebot4Button> turtlebot4_buttons_;
+  std::vector<Turtlebot4MenuEntry> turtlebot4_menu_entries_;
+  std::map<std::string, turtlebot4_function_callback_t> function_callbacks_;
+
+  // Display
+  std::unique_ptr<Display> display_;
+
+  // Buttons
+  std::unique_ptr<Buttons> buttons_;
+
+  // Leds
+  std::unique_ptr<Leds> leds_;
+
+  // Actions
+  std::unique_ptr<Turtlebot4Action<Dock>> dock_client_;
+  std::unique_ptr<Turtlebot4Action<Undock>> undock_client_;
+  std::unique_ptr<Turtlebot4Action<WallFollow>> wall_follow_client_;
+
+  // Services
+  std::unique_ptr<Turtlebot4Service<EStop>> estop_client_;
+  std::unique_ptr<Turtlebot4Service<Power>> power_client_;
+
+  // Timers
+  rclcpp::TimerBase::SharedPtr display_timer_;
+  rclcpp::TimerBase::SharedPtr buttons_timer_;
+  rclcpp::TimerBase::SharedPtr leds_timer_;
+  rclcpp::TimerBase::SharedPtr wifi_timer_;
+  rclcpp::TimerBase::SharedPtr comms_timer_;
+
+  // Subscribers
+  rclcpp::Subscription<sensor_msgs::msg::BatteryState>::SharedPtr battery_sub_;
+  rclcpp::Subscription<irobot_create_msgs::msg::WheelStatus>::SharedPtr wheel_status_sub_;
+
+  // Publishers
+  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr ip_pub_;
+
+  // Store current wheels state
+  bool wheels_enabled_;
+
+  // Timeout for when comms are considered disconnected
+  uint32_t comms_timeout_ms_;
+
+  // Turtlebot4 Model
+  Turtlebot4Model model_;
+};
+
+}  // namespace turtlebot4
+
+#endif  // TURTLEBOT4_NODE__TURTLEBOT4_HPP_

--- a/turtlebot4_node/include/turtlebot4_node/utils.hpp
+++ b/turtlebot4_node/include/turtlebot4_node/utils.hpp
@@ -28,11 +28,11 @@
 namespace turtlebot4
 {
 
-#define CREATE3_BUTTON_COUNT 3
-#define HMI_BUTTON_COUNT 4
-#define TOTAL_BUTTON_COUNT 7
+static constexpr auto CREATE3_BUTTON_COUNT = 3;
+static constexpr auto HMI_BUTTON_COUNT = 4;
+static constexpr auto TOTAL_BUTTON_COUNT = 7;
 
-#define UNKNOWN_IP "UNKNOWN"
+static const std::string UNKNOWN_IP = "UNKNOWN";
 
 enum class Turtlebot4Model
 {

--- a/turtlebot4_node/include/turtlebot4_node/utils.hpp
+++ b/turtlebot4_node/include/turtlebot4_node/utils.hpp
@@ -32,24 +32,6 @@ namespace turtlebot4
 #define HMI_BUTTON_COUNT 4
 #define TOTAL_BUTTON_COUNT 7
 
-// Pin definitions
-#define HMI_BUTTON_1_PIN 13
-#define HMI_BUTTON_2_PIN 19
-#define HMI_BUTTON_3_PIN 16
-#define HMI_BUTTON_4_PIN 26
-
-#define HMI_LED_POWER_PIN         17
-#define HMI_LED_MOTORS_PIN        18
-#define HMI_LED_COMMS_PIN         27
-#define HMI_LED_WIFI_PIN          24
-#define HMI_LED_BATTERY_GREEN_PIN 22
-#define HMI_LED_BATTERY_RED_PIN   23
-#define HMI_LED_USER_1_PIN        25
-#define HMI_LED_USER_2_GREEN_PIN  6
-#define HMI_LED_USER_2_RED_PIN    12
-
-#define HMI_DISPLAY_RESET_PIN     2
-
 #define UNKNOWN_IP "UNKNOWN"
 
 enum class Turtlebot4Model
@@ -60,8 +42,8 @@ enum class Turtlebot4Model
 
 static std::map<Turtlebot4Model, std::string> Turtlebot4ModelName
 {
-  {Turtlebot4Model::LITE, "Lite"},
-  {Turtlebot4Model::STANDARD, "Standard"}
+  {Turtlebot4Model::LITE, "lite"},
+  {Turtlebot4Model::STANDARD, "standard"}
 };
 
 typedef std::function<void (void)> turtlebot4_function_callback_t;

--- a/turtlebot4_node/include/turtlebot4_node/utils.hpp
+++ b/turtlebot4_node/include/turtlebot4_node/utils.hpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 Clearpath Robotics, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Roni Kreinin (rkreinin@clearpathrobotics.com)
+ */
+
+#ifndef TURTLEBOT4_NODE__UTILS_HPP_
+#define TURTLEBOT4_NODE__UTILS_HPP_
+
+#include <string>
+#include <vector>
+#include <functional>
+#include <chrono>
+#include <map>
+
+namespace turtlebot4
+{
+
+#define CREATE3_BUTTON_COUNT 3
+#define HMI_BUTTON_COUNT 4
+#define TOTAL_BUTTON_COUNT 7
+
+// Pin definitions
+#define HMI_BUTTON_1_PIN 13
+#define HMI_BUTTON_2_PIN 19
+#define HMI_BUTTON_3_PIN 16
+#define HMI_BUTTON_4_PIN 26
+
+#define HMI_LED_POWER_PIN         17
+#define HMI_LED_MOTORS_PIN        18
+#define HMI_LED_COMMS_PIN         27
+#define HMI_LED_WIFI_PIN          24
+#define HMI_LED_BATTERY_GREEN_PIN 22
+#define HMI_LED_BATTERY_RED_PIN   23
+#define HMI_LED_USER_1_PIN        25
+#define HMI_LED_USER_2_GREEN_PIN  6
+#define HMI_LED_USER_2_RED_PIN    12
+
+#define HMI_DISPLAY_RESET_PIN     2
+
+#define UNKNOWN_IP "UNKNOWN"
+
+enum class Turtlebot4Model
+{
+  LITE,
+  STANDARD
+};
+
+static std::map<Turtlebot4Model, std::string> Turtlebot4ModelName
+{
+  {Turtlebot4Model::LITE, "Lite"},
+  {Turtlebot4Model::STANDARD, "Standard"}
+};
+
+typedef std::function<void (void)> turtlebot4_function_callback_t;
+
+}  // namespace turtlebot4
+
+#endif  // TURTLEBOT4_NODE__UTILS_HPP_

--- a/turtlebot4_node/include/turtlebot4_node/utils.hpp
+++ b/turtlebot4_node/include/turtlebot4_node/utils.hpp
@@ -34,6 +34,32 @@ static constexpr auto TOTAL_BUTTON_COUNT = 7;
 
 static const std::string UNKNOWN_IP = "UNKNOWN";
 
+enum Turtlebot4LedEnum
+{
+  POWER,
+  MOTORS,
+  COMMS,
+  WIFI,
+  BATTERY,
+  USER_1,
+  USER_2,
+  COUNT
+};
+
+enum Turtlebot4LedType
+{
+  GREEN_ONLY,
+  RED_GREEN
+};
+
+enum Turtlebot4LedColor
+{
+  OFF = 0,
+  GREEN = 1,
+  RED = 2,
+  YELLOW = 3
+};
+
 enum class Turtlebot4Model
 {
   LITE,

--- a/turtlebot4_node/package.xml
+++ b/turtlebot4_node/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>turtlebot4_node</name>
+  <version>0.0.0</version>
+  <description>Turtlebot4 Node</description>
+  <maintainer email="rkreinin@clearpathrobotics.com">rkreinin</maintainer>
+  <license>Apache 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>rclcpp_action</depend>
+  <depend>rcutils</depend>
+  <depend>std_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>irobot_create_msgs</depend>
+  <depend>turtlebot4_msgs</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/turtlebot4_node/package.xml
+++ b/turtlebot4_node/package.xml
@@ -14,8 +14,8 @@
   <depend>rcutils</depend>
   <depend>std_msgs</depend>
   <depend>sensor_msgs</depend>
-  <depend>irobot_create_msgs</depend>
   <depend>turtlebot4_msgs</depend>
+  <depend>irobot_create_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/turtlebot4_node/src/buttons.cpp
+++ b/turtlebot4_node/src/buttons.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2021 Clearpath Robotics, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Roni Kreinin (rkreinin@clearpathrobotics.com)
+ */
+
+#include "turtlebot4_node/buttons.hpp"
+#include <iostream>
+#include <vector>
+#include <memory>
+#include <utility>
+
+using turtlebot4::Buttons;
+
+Buttons::Buttons(
+  Turtlebot4Model model,
+  std::vector<Turtlebot4Button> buttons,
+  std::shared_ptr<rclcpp::Node> & nh)
+: model_(model),
+  buttons_(buttons),
+  nh_(nh)
+{
+  RCLCPP_INFO(nh_->get_logger(), "Buttons Init");
+
+  create3_buttons_sub_ = nh_->create_subscription<irobot_create_msgs::msg::InterfaceButtons>(
+    "interface_buttons",
+    rclcpp::SensorDataQoS(),
+    std::bind(&Buttons::create3_buttons_callback, this, std::placeholders::_1));
+
+  if (model_ == Turtlebot4Model::STANDARD) {
+    hmi_buttons_sub_ = nh_->create_subscription<turtlebot4_msgs::msg::UserButton>(
+      "hmi/buttons",
+      rclcpp::SensorDataQoS(),
+      std::bind(&Buttons::hmi_buttons_callback, this, std::placeholders::_1));
+  }
+}
+
+/**
+ * @brief Poll buttons, call callbacks if pressed
+ */
+void Buttons::spin_once()
+{
+  // Spin buttons
+  for (size_t i = 0; i < buttons_.size(); i++) {
+    buttons_.at(i).spin_once();
+  }
+}
+
+void Buttons::hmi_buttons_callback(
+  const turtlebot4_msgs::msg::UserButton::SharedPtr hmi_buttons_msg)
+{
+  for (uint8_t i = 0; i < HMI_BUTTON_COUNT; i++) {
+    buttons_.at(CREATE3_BUTTON_COUNT + i).set_state(
+      static_cast<Turtlebot4ButtonState>(hmi_buttons_msg->button[i]));
+  }
+}
+
+void Buttons::create3_buttons_callback(
+  const irobot_create_msgs::msg::InterfaceButtons::SharedPtr create3_buttons_msg)
+{
+  buttons_.at(CREATE3_1).set_state(
+    static_cast<Turtlebot4ButtonState>(create3_buttons_msg->button_1.
+    is_pressed));
+  buttons_.at(CREATE3_POWER).set_state(
+    static_cast<Turtlebot4ButtonState>(create3_buttons_msg->
+    button_power.is_pressed));
+  buttons_.at(CREATE3_2).set_state(
+    static_cast<Turtlebot4ButtonState>(create3_buttons_msg->button_2.
+    is_pressed));
+}

--- a/turtlebot4_node/src/display.cpp
+++ b/turtlebot4_node/src/display.cpp
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2021 Clearpath Robotics, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Roni Kreinin (rkreinin@clearpathrobotics.com)
+ */
+
+#include "turtlebot4_node/display.hpp"
+
+#include <string>
+#include <vector>
+#include <memory>
+#include <utility>
+
+using turtlebot4::Display;
+using turtlebot4::Turtlebot4MenuEntry;
+
+/**
+ * @brief Display constructor
+ * @input nh - Turtlebot4 Node Handle
+ */
+Display::Display(
+  std::vector<Turtlebot4MenuEntry> entries,
+  std::shared_ptr<rclcpp::Node> & nh)
+: nh_(nh),
+  menu_entries_(entries),
+  scroll_position_(0),
+  selected_line_(0),
+  ip_(UNKNOWN_IP),
+  battery_percentage_(0)
+{
+  RCLCPP_INFO(nh_->get_logger(), "Init Display");
+
+  display_pub_ =
+    nh_->create_publisher<turtlebot4_msgs::msg::UserDisplay>(
+    "hmi/display",
+    rclcpp::SensorDataQoS());
+  display_message_sub_ = nh_->create_subscription<std_msgs::msg::String>(
+    "hmi/display/message",
+    rclcpp::SensorDataQoS(),
+    std::bind(&Display::display_message_callback, this, std::placeholders::_1));
+
+  // Initialize menu entries
+  set_menu_entries();
+  visible_entries_ = get_visible_entries();
+}
+
+/**
+ * @brief Set IP address
+ * @input ip - IP address as std::string
+ */
+void Display::set_ip(std::string ip)
+{
+  ip_ = ip;
+}
+
+/**
+ * @brief Set battery percentage
+ * @input battery_state_msg - Battery state message from Create3
+ */
+void Display::set_battery(const sensor_msgs::msg::BatteryState::SharedPtr & battery_state_msg)
+{
+  battery_percentage_ = static_cast<int>(battery_state_msg->percentage * 100);
+}
+
+void Display::scroll_down()
+{
+  if (menu_override_) {
+    return;
+  }
+  // Last possible scroll position, last line selected
+  if (static_cast<size_t>(scroll_position_ + DISPLAY_NUM_LINES) == menu_entries_.size() &&
+    selected_line_ == DISPLAY_NUM_LINES - 1)
+  {
+    return;
+  }
+
+  if (selected_line_ == DISPLAY_NUM_LINES - 1) {
+    if (menu_entries_.size() > static_cast<size_t>(scroll_position_ + DISPLAY_NUM_LINES)) {
+      scroll_position_++;
+    }
+  } else {
+    selected_line_++;
+  }
+}
+
+void Display::scroll_up()
+{
+  if (menu_override_) {
+    return;
+  }
+  // First scroll position, first line selected
+  if (scroll_position_ == 0 && selected_line_ == 0) {
+    return;
+  }
+
+  if (selected_line_ == 0) {
+    scroll_position_--;
+  } else {
+    selected_line_--;
+  }
+}
+
+void Display::select()
+{
+  if (menu_override_) {
+    return;
+  }
+
+  if (visible_entries_[selected_line_].cb_ != nullptr) {
+    visible_entries_[selected_line_].cb_();
+  }
+}
+
+void Display::back()
+{
+  if (menu_override_) {
+    menu_override_ = false;
+  } else {
+    scroll_position_ = 0;
+    selected_line_ = 0;
+  }
+}
+
+void Display::update_header()
+{
+  header_ = ip_ + " " + std::to_string(battery_percentage_) + "%";
+
+  // Pad string
+  if (header_.length() < DISPLAY_CHAR_PER_LINE_HEADER) {
+    header_.insert(header_.length(), DISPLAY_CHAR_PER_LINE_HEADER - header_.length(), ' ');
+  } else if (header_.length() > DISPLAY_CHAR_PER_LINE_HEADER) {
+    // Remove excess characters
+    header_ = header_.substr(0, DISPLAY_CHAR_PER_LINE_HEADER);
+  }
+}
+
+/**
+ * @brief Format and return default display message
+ */
+void Display::set_menu_entries()
+{
+  for (auto & entry : menu_entries_) {
+    pad_line(entry.name_);
+  }
+}
+
+void Display::pad_line(std::string & line)
+{
+  // Pad string
+  if (line.length() < DISPLAY_CHAR_PER_LINE) {
+    line.insert(line.length(), DISPLAY_CHAR_PER_LINE - line.length(), ' ');
+  } else if (line.length() > DISPLAY_CHAR_PER_LINE) {
+    // Remove excess characters
+    line = line.substr(0, DISPLAY_CHAR_PER_LINE);
+  }
+}
+
+std::vector<Turtlebot4MenuEntry> Display::get_visible_entries()
+{
+  std::vector<Turtlebot4MenuEntry>::const_iterator first = menu_entries_.begin() + scroll_position_;
+  std::vector<Turtlebot4MenuEntry>::const_iterator last;
+
+  if (menu_entries_.size() > static_cast<size_t>(scroll_position_ + DISPLAY_NUM_LINES)) {
+    last = menu_entries_.begin() + scroll_position_ + DISPLAY_NUM_LINES;
+  } else {
+    last = menu_entries_.end();
+  }
+  return std::vector<Turtlebot4MenuEntry>(first, last);
+}
+
+void Display::show_message(std::vector<std::string> message)
+{
+  std::vector<std::string>::const_iterator first = message.begin();
+  std::vector<std::string>::const_iterator last;
+
+  if (message.size() > static_cast<size_t>(DISPLAY_NUM_LINES)) {
+    last = message.begin() + DISPLAY_NUM_LINES;
+  } else {
+    last = message.end();
+  }
+  display_lines_ = std::vector<std::string>(first, last);
+
+  for (auto & line : display_lines_) {
+    pad_line(line);
+  }
+
+  menu_override_ = true;
+}
+
+void Display::show_message(std::string message)
+{
+  display_lines_ = std::vector<std::string>(DISPLAY_NUM_LINES);
+
+  for (int i = 0; i < DISPLAY_NUM_LINES; i++) {
+    if (message.length() < static_cast<size_t>(DISPLAY_CHAR_PER_LINE * i)) {
+      display_lines_[i] = "";
+    } else if (message.length() < static_cast<size_t>(DISPLAY_CHAR_PER_LINE * (i + 1))) {
+      display_lines_[i] =
+        message.substr(DISPLAY_CHAR_PER_LINE * i, message.length() - (DISPLAY_CHAR_PER_LINE * i));
+    } else {
+      display_lines_[i] = message.substr(DISPLAY_CHAR_PER_LINE * i, DISPLAY_CHAR_PER_LINE);
+    }
+  }
+
+  for (auto & line : display_lines_) {
+    pad_line(line);
+  }
+
+  menu_override_ = true;
+}
+
+/**
+ * @brief Update display
+ */
+void Display::update()
+{
+  update_header();
+  visible_entries_ = get_visible_entries();
+
+  auto display_msg = std::make_unique<turtlebot4_msgs::msg::UserDisplay>();
+
+  display_msg->header = header_;
+
+  if (menu_override_) {
+    display_msg->selected_entry = -1;
+    for (size_t i = 0; i < display_lines_.size(); i++) {
+      display_msg->entries[i] = display_lines_.at(i);
+    }
+  } else {
+    display_msg->selected_entry = selected_line_;
+    for (size_t i = 0; i < visible_entries_.size(); i++) {
+      display_msg->entries[i] = visible_entries_.at(i).name_;
+    }
+  }
+
+  display_pub_->publish(std::move(display_msg));
+}
+
+/**
+ * @brief Spin Once
+ */
+void Display::spin_once()
+{
+  update();
+}
+
+void Display::display_message_callback(const std_msgs::msg::String::SharedPtr display_msg)
+{
+  show_message(display_msg->data);
+}

--- a/turtlebot4_node/src/display.cpp
+++ b/turtlebot4_node/src/display.cpp
@@ -35,6 +35,7 @@ Display::Display(
   std::shared_ptr<rclcpp::Node> & nh)
 : nh_(nh),
   menu_entries_(entries),
+  menu_override_(false),
   scroll_position_(0),
   selected_line_(0),
   ip_(UNKNOWN_IP),
@@ -133,19 +134,6 @@ void Display::back()
   }
 }
 
-void Display::update_header()
-{
-  header_ = ip_ + " " + std::to_string(battery_percentage_) + "%";
-
-  // Pad string
-  if (header_.length() < DISPLAY_CHAR_PER_LINE_HEADER) {
-    header_.insert(header_.length(), DISPLAY_CHAR_PER_LINE_HEADER - header_.length(), ' ');
-  } else if (header_.length() > DISPLAY_CHAR_PER_LINE_HEADER) {
-    // Remove excess characters
-    header_ = header_.substr(0, DISPLAY_CHAR_PER_LINE_HEADER);
-  }
-}
-
 /**
  * @brief Format and return default display message
  */
@@ -226,12 +214,12 @@ void Display::show_message(std::string message)
  */
 void Display::update()
 {
-  update_header();
   visible_entries_ = get_visible_entries();
 
   auto display_msg = std::make_unique<turtlebot4_msgs::msg::UserDisplay>();
 
-  display_msg->header = header_;
+  display_msg->ip = ip_;
+  display_msg->battery = std::to_string(battery_percentage_);
 
   if (menu_override_) {
     display_msg->selected_entry = -1;

--- a/turtlebot4_node/src/leds.cpp
+++ b/turtlebot4_node/src/leds.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2021 Clearpath Robotics, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Roni Kreinin (rkreinin@clearpathrobotics.com)
+ */
+
+#include "turtlebot4_node/leds.hpp"
+
+#include <memory>
+
+using turtlebot4::Leds;
+
+Leds::Leds(
+  std::shared_ptr<rclcpp::Node> & nh)
+: nh_(nh)
+{
+  RCLCPP_INFO(nh_->get_logger(), "Leds Init");
+
+  // Power
+  leds_ = {
+    {Turtlebot4LedEnum::POWER, std::make_shared<Turtlebot4Led>(Turtlebot4LedType::GREEN_ONLY)},
+    {Turtlebot4LedEnum::MOTORS, std::make_shared<Turtlebot4Led>(Turtlebot4LedType::GREEN_ONLY)},
+    {Turtlebot4LedEnum::COMMS, std::make_shared<Turtlebot4Led>(Turtlebot4LedType::GREEN_ONLY)},
+    {Turtlebot4LedEnum::WIFI, std::make_shared<Turtlebot4Led>(Turtlebot4LedType::GREEN_ONLY)},
+    {Turtlebot4LedEnum::BATTERY, std::make_shared<Turtlebot4Led>(Turtlebot4LedType::RED_GREEN)},
+    {Turtlebot4LedEnum::USER_1, std::make_shared<Turtlebot4Led>(Turtlebot4LedType::GREEN_ONLY)},
+    {Turtlebot4LedEnum::USER_2, std::make_shared<Turtlebot4Led>(Turtlebot4LedType::RED_GREEN)},
+  };
+
+  user_led_sub_ = nh_->create_subscription<turtlebot4_msgs::msg::UserLed>(
+    "/hmi/led",
+    rclcpp::SensorDataQoS(),
+    std::bind(&Leds::user_led_callback, this, std::placeholders::_1));
+
+  leds_[Turtlebot4LedEnum::POWER]->create_publisher(nh_, "/hmi/led/_power");
+  leds_[Turtlebot4LedEnum::MOTORS]->create_publisher(nh_, "/hmi/led/_motors");
+  leds_[Turtlebot4LedEnum::COMMS]->create_publisher(nh_, "/hmi/led/_comms");
+  leds_[Turtlebot4LedEnum::WIFI]->create_publisher(nh_, "/hmi/led/_wifi");
+  leds_[Turtlebot4LedEnum::BATTERY]->create_publisher(nh_, "/hmi/led/_battery");
+  leds_[Turtlebot4LedEnum::USER_1]->create_publisher(nh_, "/hmi/led/_user1");
+  leds_[Turtlebot4LedEnum::USER_2]->create_publisher(nh_, "/hmi/led/_user2");
+}
+
+void Leds::spin_once()
+{
+  for (uint8_t i = 0; i < Turtlebot4LedEnum::COUNT; i++) {
+    leds_[static_cast<Turtlebot4LedEnum>(i)]->spin_once();
+  }
+}
+
+void Leds::user_led_callback(const turtlebot4_msgs::msg::UserLed user_led_msg)
+{
+  Turtlebot4LedEnum led = user_led_msg.led == 0 ? USER_1 : USER_2;
+  blink(
+    led, user_led_msg.blink_period, user_led_msg.duty_cycle,
+    static_cast<Turtlebot4LedColor>(user_led_msg.color));
+}
+
+void Leds::set_led(Turtlebot4LedEnum led, Turtlebot4LedColor color)
+{
+  if (color == Turtlebot4LedColor::OFF) {
+    blink(led, 1000, 0.0, color);
+  } else {
+    blink(led, 1000, 1.0, color);
+  }
+}
+
+void Leds::blink(
+  Turtlebot4LedEnum led, uint32_t blink_period_ms, double duty_cycle,
+  Turtlebot4LedColor color)
+{
+  // Invalid duty cycle
+  if (duty_cycle > 1.0 || duty_cycle < 0.0) {
+    RCLCPP_ERROR(nh_->get_logger(), "Invalid duty cycle %f", duty_cycle);
+    return;
+  }
+
+  if (color > Turtlebot4LedColor::GREEN && leds_[led]->type_ == Turtlebot4LedType::GREEN_ONLY) {
+    RCLCPP_ERROR(nh_->get_logger(), "Invalid color %d for led %d", color, led);
+    return;
+  }
+
+  leds_[led]->on_period_ms_ = blink_period_ms * duty_cycle;
+  leds_[led]->off_period_ms_ = blink_period_ms * (1 - duty_cycle);
+  leds_[led]->blink_color_ = color;
+}

--- a/turtlebot4_node/src/main.cpp
+++ b/turtlebot4_node/src/main.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Clearpath Robotics, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Roni Kreinin (rkreinin@clearpathrobotics.com)
+ */
+
+#include <rcutils/cmdline_parser.h>
+#include <rclcpp/rclcpp.hpp>
+
+#include <chrono>
+#include <memory>
+#include <string>
+
+#include "turtlebot4_node/turtlebot4.hpp"
+#include "turtlebot4_node/utils.hpp"
+
+
+int main(int argc, char * argv[])
+{
+  setvbuf(stdout, NULL, _IONBF, BUFSIZ);
+
+  rclcpp::init(argc, argv);
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+
+  auto turtlebot4 = std::make_shared<turtlebot4::Turtlebot4>();
+
+  executor.add_node(turtlebot4);
+  executor.spin();
+
+  rclcpp::shutdown();
+
+  return 0;
+}

--- a/turtlebot4_node/src/main.cpp
+++ b/turtlebot4_node/src/main.cpp
@@ -29,8 +29,6 @@
 
 int main(int argc, char * argv[])
 {
-  setvbuf(stdout, NULL, _IONBF, BUFSIZ);
-
   rclcpp::init(argc, argv);
 
   rclcpp::executors::SingleThreadedExecutor executor;

--- a/turtlebot4_node/src/turtlebot4.cpp
+++ b/turtlebot4_node/src/turtlebot4.cpp
@@ -89,13 +89,13 @@ Turtlebot4::Turtlebot4()
 
   this->declare_parameter(
     "buttons.create3_1",
-    std::vector<std::string>({"Dock", "", ""}));
+    std::vector<std::string>({"Dock", "Wall Follow Left", "2000"}));
   this->declare_parameter(
     "buttons.create3_power",
     std::vector<std::string>({"EStop", "Power", "3000"}));
   this->declare_parameter(
     "buttons.create3_2",
-    std::vector<std::string>({"Undock", "", ""}));
+    std::vector<std::string>({"Undock", "Wall Follow Right", "2000"}));
 
   if (model_ == Turtlebot4Model::STANDARD) {
     this->declare_parameter("buttons.hmi_1", std::vector<std::string>({"Select", "", ""}));
@@ -153,7 +153,8 @@ Turtlebot4::Turtlebot4()
   function_callbacks_ = {
     {"Dock", std::bind(&Turtlebot4::dock_function_callback, this)},
     {"Undock", std::bind(&Turtlebot4::undock_function_callback, this)},
-    {"Follow", std::bind(&Turtlebot4::follow_function_callback, this)},
+    {"Wall Follow Left", std::bind(&Turtlebot4::wall_follow_left_function_callback, this)},
+    {"Wall Follow Right", std::bind(&Turtlebot4::wall_follow_right_function_callback, this)},
     {"EStop", std::bind(&Turtlebot4::estop_function_callback, this)},
     {"Power", std::bind(&Turtlebot4::power_function_callback, this)},
     {"Scroll Up", std::bind(&Turtlebot4::scroll_up_function_callback, this)},
@@ -361,11 +362,34 @@ void Turtlebot4::undock_function_callback()
 /**
  * @brief Sends follow action goal
  */
-void Turtlebot4::follow_function_callback()
+void Turtlebot4::wall_follow_left_function_callback()
 {
   if (wall_follow_client_ != nullptr) {
-    RCLCPP_INFO(this->get_logger(), "Wall follow");
-    wall_follow_client_->send_goal();
+    RCLCPP_INFO(this->get_logger(), "Wall Follow Left");
+    auto goal_msg = std::make_shared<WallFollow::Goal>();
+    auto runtime = builtin_interfaces::msg::Duration();
+    runtime.sec = 10;
+    goal_msg->follow_side = WallFollow::Goal::FOLLOW_LEFT;
+    goal_msg->max_runtime = runtime;
+    wall_follow_client_->send_goal(goal_msg);
+  } else {
+    RCLCPP_ERROR(this->get_logger(), "Follow client NULL");
+  }
+}
+
+/**
+ * @brief Sends follow action goal
+ */
+void Turtlebot4::wall_follow_right_function_callback()
+{
+  if (wall_follow_client_ != nullptr) {
+    RCLCPP_INFO(this->get_logger(), "Wall Follow Right");
+    auto goal_msg = std::make_shared<WallFollow::Goal>();
+    auto runtime = builtin_interfaces::msg::Duration();
+    runtime.sec = 10;
+    goal_msg->follow_side = WallFollow::Goal::FOLLOW_RIGHT;
+    goal_msg->max_runtime = runtime;
+    wall_follow_client_->send_goal(goal_msg);
   } else {
     RCLCPP_ERROR(this->get_logger(), "Follow client NULL");
   }


### PR DESCRIPTION
## Description

Restructured Turtlebot4 nodes.

`turtlebot4_node`:
- `turtlebot4_node` is now under the `turtlebot4` repo and controls the HMI logic.
- Display and LED states are published by `turtlebot4_node`
- `turtlebot4_node` subscribes to the Button states

`turtlebot4_base`:
- `turtlebot4_base` is now the node that runs on the Raspberry Pi of the Turtlebot4 Standard. It is not used for Turtlebot4 Lite.
- This node subscribes to Display and LED states, and publishes Button states
- This node accesses the gpio and i2c lines of the Raspberry Pi

`turtlebot4_ignition_toolbox`:
- New Package for Ignition nodes
- `turtlebot4_ignition_hmi_node` is now run when using simulator with a Standard Turtlebot4
- This node subscribes to Display states, and publishes Button states
- The node converts the received Display topic to a standard string topic that Ignition can receive
- LED state is sent directly from `turtlebot4_node` to the `ros_ign_bridge` as it does not need to be converted.

Additional changes:
- I2C bus now resets after 3 consecutive errors rather than 1 to prevent the screen from blinking.
- Replaced Wall Follow action with Wall Follow Left and Wall Follow Right
- Added new UserDisplay message

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce. Also list any relevant details for your test configuration.

```bash
# Run this command
ros2 launch turtlebot4_bringup robot.launch.py
ros2 launch turtlebot4_bringup robot.launch.py model:=lite
ros2 launch turtlebot4_ignition_bringup ignition.launch.py
ros2 launch turtlebot4_ignition_bringup ignition.launch.py model:=lite
```

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation