### PR TITLE
Add 4 new Menu Entries to HMI display for "User Program"

### DIFF
--- a/turtlebot4_node/include/turtlebot4_node/turtlebot4.hpp
+++ b/turtlebot4_node/include/turtlebot4_node/turtlebot4.hpp
@@ -23,6 +23,7 @@
 #include <sensor_msgs/msg/battery_state.hpp>
 #include <std_msgs/msg/string.hpp>
 #include <std_srvs/srv/empty.hpp>
+#include <std_msgs/msg/bool.hpp>
 
 #include <chrono>
 #include <map>
@@ -103,6 +104,10 @@ private:
   void add_menu_function_callbacks();
 
   void low_battery_animation();
+  void user_program_one_function_callback();
+  void user_program_two_function_callback();
+  void user_program_three_function_callback();
+  void user_program_four_function_callback();
 
   // Run display timer
   void display_timer(const std::chrono::milliseconds timeout);
@@ -121,6 +126,9 @@ private:
 
   // Run power off timer
   void power_off_timer(const std::chrono::milliseconds timeout);
+
+  // Run user program timer
+  void user_program_timer(const std::chrono::milliseconds timeout);
 
   // IP
   std::string get_ip();
@@ -163,6 +171,7 @@ private:
   rclcpp::TimerBase::SharedPtr wifi_timer_;
   rclcpp::TimerBase::SharedPtr comms_timer_;
   rclcpp::TimerBase::SharedPtr power_off_timer_;
+  rclcpp::TimerBase::SharedPtr user_program_timer_;
 
   // Subscribers
   rclcpp::Subscription<sensor_msgs::msg::BatteryState>::SharedPtr battery_sub_;
@@ -170,6 +179,10 @@ private:
 
   // Publishers
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr ip_pub_;
+  rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr user_program_pub_one;
+  rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr user_program_pub_two;
+  rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr user_program_pub_three;
+  rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr user_program_pub_four;
 
   // Store current wheels state
   bool wheels_enabled_;

--- a/turtlebot4_node/src/turtlebot4.cpp
+++ b/turtlebot4_node/src/turtlebot4.cpp
@@ -141,6 +141,19 @@ Turtlebot4::Turtlebot4()
   ip_pub_ = this->create_publisher<std_msgs::msg::String>(
     "ip",
     rclcpp::QoS(rclcpp::KeepLast(10)));
+  
+  user_program_pub_one = this->create_publisher<std_msgs::msg::Bool>(
+    "user_program_1",
+    rclcpp::QoS(rclcpp::KeepLast(10)));
+  user_program_pub_two = this->create_publisher<std_msgs::msg::Bool>(
+    "user_program_2",
+    rclcpp::QoS(rclcpp::KeepLast(10)));
+  user_program_pub_three = this->create_publisher<std_msgs::msg::Bool>(
+    "user_program_3",
+    rclcpp::QoS(rclcpp::KeepLast(10)));
+  user_program_pub_four = this->create_publisher<std_msgs::msg::Bool>(
+    "user_program_4",
+    rclcpp::QoS(rclcpp::KeepLast(10)));
 
   // Create action/service clients
   dock_client_ = std::make_unique<Turtlebot4Action<Dock>>(node_handle_, "dock");
@@ -167,6 +180,10 @@ Turtlebot4::Turtlebot4()
     {"Select", std::bind(&Turtlebot4::select_function_callback, this)},
     {"Back", std::bind(&Turtlebot4::back_function_callback, this)},
     {"Help", std::bind(&Turtlebot4::help_function_callback, this)},
+    {"User Program 1", std::bind(&Turtlebot4::user_program_one_function_callback, this)},
+    {"User Program 2", std::bind(&Turtlebot4::user_program_two_function_callback, this)},
+    {"User Program 3", std::bind(&Turtlebot4::user_program_three_function_callback, this)},
+    {"User Program 4", std::bind(&Turtlebot4::user_program_four_function_callback, this)},
   };
 
   // Set function callbacks
@@ -206,6 +223,7 @@ void Turtlebot4::run()
 
   buttons_timer(std::chrono::milliseconds(10));
   wifi_timer(std::chrono::milliseconds(5000));
+  user_program_timer(std::chrono::milliseconds(500));
   comms_timer(std::chrono::milliseconds(comms_timeout_ms_));
 }
 
@@ -277,6 +295,28 @@ void Turtlebot4::wifi_timer(const std::chrono::milliseconds timeout)
           leds_->set_led(WIFI, GREEN);
         }
       }
+    });
+}
+
+/**
+ * @brief Creates and runs timer to check Wifi connection
+ * @input timeout - Sets timer period in milliseconds
+ */
+void Turtlebot4::user_program_timer(const std::chrono::milliseconds timeout)
+{
+  user_program_timer_ = this->create_wall_timer(
+    timeout,
+    [this]() -> void
+    {
+      
+      // Publish Bool
+      std_msgs::msg::Bool msg;
+      msg.data = false;
+      this->user_program_pub_one->publish(std::move(msg));
+      this->user_program_pub_two->publish(std::move(msg));
+      this->user_program_pub_three->publish(std::move(msg));
+      this->user_program_pub_four->publish(std::move(msg));
+
     });
 }
 
@@ -562,6 +602,50 @@ void Turtlebot4::help_function_callback()
     help_message.push_back("4:" + turtlebot4_buttons_[Turtlebot4ButtonEnum::HMI_4].short_function_);
     display_->show_message(help_message);
   }
+}
+
+/**
+ * @brief User Program 1 callback function to publish bool
+ */
+void Turtlebot4::user_program_one_function_callback()
+{
+    // Publish Bool
+    std_msgs::msg::Bool msg;
+    msg.data = true;
+    this->user_program_pub_one->publish(std::move(msg));
+}
+
+/**
+ * @brief User Program 2 callback function to publish bool
+ */
+void Turtlebot4::user_program_two_function_callback()
+{
+    // Publish Bool
+    std_msgs::msg::Bool msg;
+    msg.data = true;
+    this->user_program_pub_two->publish(std::move(msg));
+}
+
+/**
+ * @brief User Program 3 callback function to publish bool
+ */
+void Turtlebot4::user_program_three_function_callback()
+{
+    // Publish Bool
+    std_msgs::msg::Bool msg;
+    msg.data = true;
+    this->user_program_pub_three->publish(std::move(msg));
+}
+
+/**
+ * @brief User Program 4 callback function to publish bool
+ */
+void Turtlebot4::user_program_four_function_callback()
+{
+    // Publish Bool
+    std_msgs::msg::Bool msg;
+    msg.data = true;
+    this->user_program_pub_four->publish(std::move(msg));
 }
 
 /**


### PR DESCRIPTION
## Description
This PR enables the users to launch their turtlebot4 application from HMI display by pressing "User Program 1" on HMI menu. Here we have created 4 new publishers that publish boolean values. Upon user selecting "User Program 1" button, we are publishing a bool  flag to be as True. This way user's can use this topic to subscribe in their projects as per their need and application.

![today](https://user-images.githubusercontent.com/24978535/185010515-870c914e-dc52-4d99-8383-af9d6b270f1f.png)
![presentation_1](https://user-images.githubusercontent.com/24978535/185010524-9c2a6202-957f-4597-9ce8-22c474dcf6b9.png)


## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

This has been test by running:
```
ros2 topic echo /user_program_1
ros2 topic echo /user_program_2
ros2 topic echo /user_program_3
ros2 topic echo /user_program_4

```
Upon user selecting the desired User Program, the data for the corresponding topic changes to true

![Screenshot from 2022-08-16 20-59-52](https://user-images.githubusercontent.com/24978535/185010958-c6a3a77d-6b88-4581-ab80-4e2abf66d8cc.png)

```bash
# Run this command
ros2 launch turtlebot4_ignition_bringup ignition.launch.py 
```

## Checklist

- [x] I have performed a self-review of my own code and reviewed by @kscottz 
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation