### PR TITLE
Function calls

### DIFF
--- a/turtlebot4_node/include/turtlebot4_node/buttons.hpp
+++ b/turtlebot4_node/include/turtlebot4_node/buttons.hpp
@@ -85,7 +85,8 @@ struct Turtlebot4Button
   Turtlebot4ButtonState next_state_;
 
   explicit Turtlebot4Button(std::vector<std::string> params)
-  : current_state_(RELEASED),
+  : long_press_duration_ms_(0),
+    current_state_(RELEASED),
     next_state_(RELEASED)
   {
     // Short press function only
@@ -160,22 +161,20 @@ struct Turtlebot4Button
   void short_press()
   {
     if (short_cb_ != nullptr) {
-      short_cb_();
-      if (function_call_cb_ != nullptr)
-      {
+      if (function_call_cb_ != nullptr) {
         function_call_cb_(short_function_);
       }
+      short_cb_();
     }
   }
 
   void long_press()
   {
     if (long_cb_ != nullptr) {
-      long_cb_();
-      if (function_call_cb_ != nullptr)
-      {
+      if (function_call_cb_ != nullptr) {
         function_call_cb_(long_function_);
       }
+      long_cb_();
     }
   }
 };

--- a/turtlebot4_node/include/turtlebot4_node/buttons.hpp
+++ b/turtlebot4_node/include/turtlebot4_node/buttons.hpp
@@ -76,6 +76,7 @@ struct Turtlebot4Button
   std::string long_function_;
   turtlebot4_function_callback_t short_cb_;
   turtlebot4_function_callback_t long_cb_;
+  turtlebot4_function_call_callback_t function_call_cb_;
 
   int long_press_duration_ms_;
   std::chrono::time_point<std::chrono::steady_clock> last_start_pressed_time_;
@@ -160,6 +161,10 @@ struct Turtlebot4Button
   {
     if (short_cb_ != nullptr) {
       short_cb_();
+      if (function_call_cb_ != nullptr)
+      {
+        function_call_cb_(short_function_);
+      }
     }
   }
 
@@ -167,6 +172,10 @@ struct Turtlebot4Button
   {
     if (long_cb_ != nullptr) {
       long_cb_();
+      if (function_call_cb_ != nullptr)
+      {
+        function_call_cb_(long_function_);
+      }
     }
   }
 };

--- a/turtlebot4_node/include/turtlebot4_node/display.hpp
+++ b/turtlebot4_node/include/turtlebot4_node/display.hpp
@@ -53,17 +53,15 @@ struct Turtlebot4MenuEntry
 
   /**
    * @brief Call menu function
-   * 
+   *
    */
   void function_call()
   {
-    if (function_call_cb_ != nullptr)
-    {
+    if (function_call_cb_ != nullptr) {
       function_call_cb_(function_);
     }
 
-    if (cb_ != nullptr)
-    {
+    if (cb_ != nullptr) {
       cb_();
     }
   }

--- a/turtlebot4_node/include/turtlebot4_node/display.hpp
+++ b/turtlebot4_node/include/turtlebot4_node/display.hpp
@@ -57,14 +57,14 @@ struct Turtlebot4MenuEntry
    */
   void function_call()
   {
-    if (cb_ != nullptr)
-    {
-      cb_();
-    }
-
     if (function_call_cb_ != nullptr)
     {
       function_call_cb_(function_);
+    }
+
+    if (cb_ != nullptr)
+    {
+      cb_();
     }
   }
 };

--- a/turtlebot4_node/include/turtlebot4_node/display.hpp
+++ b/turtlebot4_node/include/turtlebot4_node/display.hpp
@@ -42,12 +42,26 @@ static constexpr auto DISPLAY_CHAR_PER_LINE_HEADER = 21;
 
 struct Turtlebot4MenuEntry
 {
-  std::string name_;
+  std::string name_, function_;
   turtlebot4_function_callback_t cb_;
+  turtlebot4_function_call_callback_t function_call_cb_;
 
   explicit Turtlebot4MenuEntry(std::string name)
-  : name_(name)
+  : name_(name),
+    function_(name)
   {}
+
+  void function_call()
+  {
+    if (cb_ != nullptr)
+    {
+      cb_();
+      if (function_call_cb_ != nullptr)
+      {
+        function_call_cb_(function_);
+      }
+    }
+  }
 };
 
 class Display

--- a/turtlebot4_node/include/turtlebot4_node/display.hpp
+++ b/turtlebot4_node/include/turtlebot4_node/display.hpp
@@ -51,15 +51,20 @@ struct Turtlebot4MenuEntry
     function_(name)
   {}
 
+  /**
+   * @brief Call menu function
+   * 
+   */
   void function_call()
   {
     if (cb_ != nullptr)
     {
       cb_();
-      if (function_call_cb_ != nullptr)
-      {
-        function_call_cb_(function_);
-      }
+    }
+
+    if (function_call_cb_ != nullptr)
+    {
+      function_call_cb_(function_);
     }
   }
 };

--- a/turtlebot4_node/include/turtlebot4_node/turtlebot4.hpp
+++ b/turtlebot4_node/include/turtlebot4_node/turtlebot4.hpp
@@ -98,6 +98,7 @@ private:
   void back_function_callback();
   void help_function_callback();
   void unused_function_callback();
+  void function_call_callback(std::string function_name);
 
   void add_button_function_callbacks();
   void add_menu_function_callbacks();
@@ -170,6 +171,7 @@ private:
 
   // Publishers
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr ip_pub_;
+  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr function_call_pub_;
 
   // Store current wheels state
   bool wheels_enabled_;

--- a/turtlebot4_node/include/turtlebot4_node/utils.hpp
+++ b/turtlebot4_node/include/turtlebot4_node/utils.hpp
@@ -73,6 +73,7 @@ static std::map<Turtlebot4Model, std::string> Turtlebot4ModelName
 };
 
 typedef std::function<void (void)> turtlebot4_function_callback_t;
+typedef std::function<void (std::string)> turtlebot4_function_call_callback_t;
 
 }  // namespace turtlebot4
 

--- a/turtlebot4_node/src/display.cpp
+++ b/turtlebot4_node/src/display.cpp
@@ -119,9 +119,7 @@ void Display::select()
     return;
   }
 
-  if (visible_entries_[selected_line_].cb_ != nullptr) {
-    visible_entries_[selected_line_].cb_();
-  }
+  visible_entries_[selected_line_].function_call();
 }
 
 void Display::back()

--- a/turtlebot4_node/src/turtlebot4.cpp
+++ b/turtlebot4_node/src/turtlebot4.cpp
@@ -142,6 +142,10 @@ Turtlebot4::Turtlebot4()
     "ip",
     rclcpp::QoS(rclcpp::KeepLast(10)));
 
+  function_call_pub_ = this->create_publisher<std_msgs::msg::String>(
+    "function_calls",
+    rclcpp::QoS(rclcpp::KeepLast(10)));
+
   // Create action/service clients
   dock_client_ = std::make_unique<Turtlebot4Action<Dock>>(node_handle_, "dock");
   undock_client_ = std::make_unique<Turtlebot4Action<Undock>>(node_handle_, "undock");
@@ -573,6 +577,17 @@ void Turtlebot4::unused_function_callback()
 }
 
 /**
+ * @brief Callback for when a function call is executed
+ */
+void Turtlebot4::function_call_callback(std::string function_name)
+{
+  std_msgs::msg::String msg;
+  msg.data = function_name;
+
+  function_call_pub_->publish(msg);
+}
+
+/**
  * @brief Creates action or service clients and adds appropriate callbacks
  * for each function declared in ROS parameters
  */
@@ -592,6 +607,8 @@ void Turtlebot4::add_button_function_callbacks()
     } else {
       button.long_cb_ = std::bind(&Turtlebot4::unused_function_callback, this);
     }
+
+    button.function_call_cb_ = std::bind(&Turtlebot4::function_call_callback, this, std::placeholders::_1);
   }
 }
 
@@ -607,6 +624,7 @@ void Turtlebot4::add_menu_function_callbacks()
     } else {
       entry.cb_ = std::bind(&Turtlebot4::unused_function_callback, this);
     }
+    entry.function_call_cb_ = std::bind(&Turtlebot4::function_call_callback, this, std::placeholders::_1);
   }
 }
 

--- a/turtlebot4_node/src/turtlebot4.cpp
+++ b/turtlebot4_node/src/turtlebot4.cpp
@@ -608,7 +608,9 @@ void Turtlebot4::add_button_function_callbacks()
       button.long_cb_ = std::bind(&Turtlebot4::unused_function_callback, this);
     }
 
-    button.function_call_cb_ = std::bind(&Turtlebot4::function_call_callback, this, std::placeholders::_1);
+    button.function_call_cb_ = std::bind(
+      &Turtlebot4::function_call_callback, this,
+      std::placeholders::_1);
   }
 }
 
@@ -624,7 +626,9 @@ void Turtlebot4::add_menu_function_callbacks()
     } else {
       entry.cb_ = std::bind(&Turtlebot4::unused_function_callback, this);
     }
-    entry.function_call_cb_ = std::bind(&Turtlebot4::function_call_callback, this, std::placeholders::_1);
+    entry.function_call_cb_ = std::bind(
+      &Turtlebot4::function_call_callback, this,
+      std::placeholders::_1);
   }
 }
 


### PR DESCRIPTION
## Description

Added a string publisher that will publish the name of a menu or button function as it is called. This feature allows external nodes to be notified when a certain function is called.

Users can also add custom named functions to the config .yaml file. The custom functions won't do anything inside `turtlebot4_node`, but the `function_calls` publisher will publish the function name when called. Users can use this to interact with their custom nodes.

Replaces #28.

## Example

![functions](https://user-images.githubusercontent.com/59886299/186686898-6b7cbf4b-0cf5-4638-ab51-b76a7bc0e5a7.gif)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

```bash
# Run this command
ros2 launch turtlebot4_bringup robot.launch.py
```

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation