### PR TITLE
Flash Comms LED based on high frequency wheel status feedback instead of low frequency battery state

### DIFF
--- a/turtlebot4_node/src/turtlebot4.cpp
+++ b/turtlebot4_node/src/turtlebot4.cpp
@@ -339,11 +339,6 @@ void Turtlebot4::battery_callback(const sensor_msgs::msg::BatteryState::SharedPt
   if (model_ == Turtlebot4Model::STANDARD) {
     display_->set_battery(battery_state_msg);
 
-    // Reset Comms timer
-    comms_timer_->cancel();
-    leds_->set_led(COMMS, GREEN);
-    comms_timer(std::chrono::milliseconds(comms_timeout_ms_));
-
     // Set Battery LED
     if (battery_state_msg->percentage > 0.5) {
       leds_->set_led(BATTERY, GREEN);
@@ -363,6 +358,11 @@ void Turtlebot4::wheel_status_callback(
   wheels_enabled_ = wheel_status_msg->wheels_enabled;
 
   if (model_ == Turtlebot4Model::STANDARD) {
+    // Reset Comms timer
+    comms_timer_->cancel();
+    leds_->set_led(COMMS, GREEN);
+    comms_timer(std::chrono::milliseconds(comms_timeout_ms_));
+
     // Set Motors LED
     if (wheels_enabled_) {
       leds_->set_led(MOTORS, GREEN);


### PR DESCRIPTION
## Description

- Move comms_timer() from battery_callback() to wheel_status_callback().

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce. Also list any relevant details for your test configuration.

```bash
# Run this command
ros2 launch package launch.py
```

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation