### PR TITLE
Use opaque function to allow for remapping of scan topics

### DIFF
--- a/turtlebot4_navigation/launch/nav2.launch.py
+++ b/turtlebot4_navigation/launch/nav2.launch.py
@@ -18,52 +18,68 @@
 from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, GroupAction, IncludeLaunchDescription
+from launch.actions import (
+    DeclareLaunchArgument,
+    GroupAction,
+    IncludeLaunchDescription,
+    OpaqueFunction
+)
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 
-from launch_ros.actions import PushRosNamespace
+from launch_ros.actions import PushRosNamespace, SetRemap
 
 
 ARGUMENTS = [
     DeclareLaunchArgument('use_sim_time', default_value='false',
                           choices=['true', 'false'],
                           description='Use sim time'),
+    DeclareLaunchArgument('params_file',
+                          default_value=PathJoinSubstitution([
+                              get_package_share_directory('turtlebot4_navigation'),
+                              'config',
+                              'nav2.yaml'
+                              ]),
+                          description='Nav2 parameters'),
+    DeclareLaunchArgument('namespace', default_value='',
+                          description='Robot namespace')
 ]
 
 
-def generate_launch_description():
-    pkg_turtlebot4_navigation = get_package_share_directory('turtlebot4_navigation')
+def launch_setup(context, *args, **kwargs):
     pkg_nav2_bringup = get_package_share_directory('nav2_bringup')
 
-    nav2_params_arg = DeclareLaunchArgument(
-        'params_file',
-        default_value=PathJoinSubstitution(
-            [pkg_turtlebot4_navigation, 'config', 'nav2.yaml']),
-        description='Nav2 parameters')
-
-    namespace_arg = DeclareLaunchArgument(
-                        'namespace',
-                        default_value='',
-                        description='Robot namespace')
-
+    nav2_params = LaunchConfiguration('params_file')
     namespace = LaunchConfiguration('namespace')
     use_sim_time = LaunchConfiguration('use_sim_time')
 
+    namespace_str = namespace.perform(context)
+    if (namespace_str and not namespace_str.startswith('/')):
+      namespace_str = '/' + namespace_str
+
+    launch_nav2 = PathJoinSubstitution(
+      [pkg_nav2_bringup, 'launch', 'navigation_launch.py'])
+
     nav2 = GroupAction([
         PushRosNamespace(namespace),
+        SetRemap(namespace_str + '/global_costmap/scan', namespace_str + '/scan'),
+        SetRemap(namespace_str + '/local_costmap/scan', namespace_str + '/scan'),
 
         IncludeLaunchDescription(
-            PythonLaunchDescriptionSource(
-                PathJoinSubstitution(
-                    [pkg_nav2_bringup, 'launch', 'navigation_launch.py'])),
-            launch_arguments={'use_sim_time': use_sim_time,
-                              'use_composition': 'False',
-                              'params_file': LaunchConfiguration('params_file')}.items()),
+            PythonLaunchDescriptionSource(launch_nav2),
+            launch_arguments=[
+                  ('use_sim_time', use_sim_time),
+                  ('params_file', nav2_params.perform(context)),
+                  ('use_composition', 'False'),
+                  ('namespace', namespace_str)
+                ]
+        ),
     ])
 
+    return [nav2]
+
+
+def generate_launch_description():
     ld = LaunchDescription(ARGUMENTS)
-    ld.add_action(nav2_params_arg)
-    ld.add_action(namespace_arg)
-    ld.add_action(nav2)
+    ld.add_action(OpaqueFunction(function=launch_setup))
     return ld

--- a/turtlebot4_navigation/launch/nav2.launch.py
+++ b/turtlebot4_navigation/launch/nav2.launch.py
@@ -55,10 +55,10 @@ def launch_setup(context, *args, **kwargs):
 
     namespace_str = namespace.perform(context)
     if (namespace_str and not namespace_str.startswith('/')):
-      namespace_str = '/' + namespace_str
+        namespace_str = '/' + namespace_str
 
     launch_nav2 = PathJoinSubstitution(
-      [pkg_nav2_bringup, 'launch', 'navigation_launch.py'])
+        [pkg_nav2_bringup, 'launch', 'navigation_launch.py'])
 
     nav2 = GroupAction([
         PushRosNamespace(namespace),


### PR DESCRIPTION
## Description

Remap scan topics when launching nav2 so that the costmaps subscribe to the correct scan topic and so that dynamic objects appear in the costmaps so that they are avoided.

Fixes https://github.com/turtlebot/turtlebot4/issues/247.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Simulated and then tested with a turtlebot4 lite to ensure that when running Nav2 + localization with and without namespacing, unmapped / dynamic obstacles appear in the costmaps and the robot avoids said obstacle. In simulation this can be done by inserting cubes / cylinders and with the real robot you can walk around the robot and observe the reactions.

```bash
# Run this command for sim
ros2 launch turtlebot4_ignition_bringup turtlebot4_ignition.launch.py nav2:=true slam:=false localization:=true rviz:=true namespace:=robot1

# Run these commands for physical robots
ros2 launch turtlebot4_viz view_robot.launch.py namespace:=robot2
ros2 launch turtlebot4_navigation localization.launch.py namespace:=/robot2 map:=office.yaml # replace with your map file
ros2 launch turtlebot4_navigation nav2.launch.py namespace:=/robot2
```

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation