### PR TITLE
Fixed gazebo camera depth not aligned with lidar

### DIFF
--- a/turtlebot4_description/urdf/sensors/oakd.urdf.xacro
+++ b/turtlebot4_description/urdf/sensors/oakd.urdf.xacro
@@ -123,7 +123,7 @@
   <gazebo reference="${name}_rgb_camera_frame">
     <sensor name="rgbd_camera" type="rgbd_camera">
       <camera>
-        <horizontal_fov>1.25</horizontal_fov>
+        <horizontal_fov>1.047</horizontal_fov>
         <image>
           <width>320</width>
           <height>240</height>


### PR DESCRIPTION
## Description

As also observed in that [post](http://official-rtab-map-forum.206.s1.nabble.com/Combine-3D-Lidar-and-RGB-D-Camera-to-create-a-single-3D-point-cloud-sensor-fusion-td10162.html#a10175), in simulation,  it seems the `horizontal_fov` parameter of `rgbd_camera` gazebo's sensor is not applied correctly either to published `camera_info` or how the rgb/depth images are captured in the simulator.
https://github.com/turtlebot/turtlebot4/blob/1d2308445cb8509382bf693554b209fd77889592/turtlebot4_description/urdf/sensors/oakd.urdf.xacro#L122-L129

It seems that we have to use original fov value `1.047` instead of `1.25` (from this [example](https://github.com/gazebosim/gz-sim/blob/ce09c0404beacd6035bf78f62349c23258fc03de/examples/worlds/sensors_demo.sdf#L452-L457)) so that data published look fine. See comparison below.




## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Commands used to test:
```bash
ros2 launch turtlebot4_ignition_bringup turtlebot4_ignition.launch.py slam:=false nav2:=true rviz:=true
ros2 run teleop_twist_keyboard teleop_twist_keyboard
```
then add DepthCloud plugin in rviz2 to show camera point cloud, and set global fixed frame to `base_link`.

With current value `1.25`, we can see that the point cloud generated from the camera's depth is not aligned with the lidar (robot is not moving):
![2024-06-29_19-18](https://github.com/turtlebot/turtlebot4/assets/2319645/effdee1d-9142-4e0f-ac1e-bfec7cefaa34)
![2024-06-29_19-20](https://github.com/turtlebot/turtlebot4/assets/2319645/af4a996b-188f-479e-8d1a-3ba32c2c9c46)

With the fix (setting value to `1.047`), the alignment is as good as we could expect. Here the same point of view than above with this PR:
![2024-06-29_19-22](https://github.com/turtlebot/turtlebot4/assets/2319645/0565173e-56e9-485f-8da5-137aa4dfc02d)
![2024-06-29_19-24](https://github.com/turtlebot/turtlebot4/assets/2319645/a50952ac-ea89-4ad4-99a5-72652d901561)
