### PR TITLE
Adds support for namespaces to TurtleBot4Navigator.

### DIFF
--- a/turtlebot4_navigation/turtlebot4_navigation/turtlebot4_navigator.py
+++ b/turtlebot4_navigation/turtlebot4_navigation/turtlebot4_navigator.py
@@ -52,8 +52,8 @@ class TurtleBot4Navigator(BasicNavigator):
     is_docked = None
     creating_path = False
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, namespace=''):
+        super().__init__(namespace=namespace)
 
         self.create_subscription(DockStatus,
                                  'dock_status',


### PR DESCRIPTION
## Description

Currently it is not possible to use the Turtlebot4Navigator while also using the concept of namespaces.
The Turtlebot4Navigator class inherits form the BasicNavigator class.
The BasicNavigators class __init fucntion has the signature:
```Python
def __init__(self, node_name='basic_navigator', namespace=''):
```
In this PR the namespace parameter is exposed in the __init function of the Turtlebot4Navigator.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I ran the tutorial code given at https://turtlebot.github.io/turtlebot4-user-manual/tutorials/turtlebot4_navigator.html#navigate-to-pose which previously failed previously because some topics could not be found. (Because their names are prefixed by the namespace).
With this change the library works fine. 

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation