### PR TITLE
footprint changed to 8 sided polygon

### DIFF
--- a/turtlebot4_navigation/config/nav2.yaml
+++ b/turtlebot4_navigation/config/nav2.yaml
@@ -135,7 +135,15 @@ local_costmap:
       width: 3
       height: 3
       resolution: 0.06
-      robot_radius: 0.175
+      #robot_radius: 0.175
+      footprint: "[[ 0.189,  0.000],
+                  [ 0.134, -0.134],
+                  [ 0.000, -0.189],
+                  [-0.134, -0.134],
+                  [-0.189,  0.000],
+                  [-0.134,  0.134],
+                  [ 0.000,  0.189],
+                  [ 0.134,  0.134]]"
       plugins: ["static_layer", "voxel_layer", "inflation_layer"]
       inflation_layer:
         plugin: "nav2_costmap_2d::InflationLayer"
@@ -174,7 +182,15 @@ global_costmap:
       publish_frequency: 1.0
       global_frame: map
       robot_base_frame: base_link
-      robot_radius: 0.175
+      #robot_radius: 0.175
+      footprint: "[[ 0.189,  0.000],
+                  [ 0.134, -0.134],
+                  [ 0.000, -0.189],
+                  [-0.134, -0.134],
+                  [-0.189,  0.000],
+                  [-0.134,  0.134],
+                  [ 0.000,  0.189],
+                  [ 0.134,  0.134]]"
       resolution: 0.06
       track_unknown_space: true
       plugins: ["static_layer", "obstacle_layer", "inflation_layer"]


### PR DESCRIPTION
## Description

The issue is create by CostCritic of MPPI Controller when `consider_footprint` is set to `true`. In this case the `controller_server` requires a footprint polygon and does not work with radius footprint.

Fixes #591.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

This is tested with Turtlebot 4 navigation demo steps.

```bash
# Run this command
ros2 launch turtlebot4_navigation nav2.launch.py
```

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation