### PR TITLE
Make footprint topic relative in collision monitor to allow using with namespace

### DIFF
--- a/turtlebot4_navigation/config/nav2.yaml
+++ b/turtlebot4_navigation/config/nav2.yaml
@@ -309,7 +309,7 @@ collision_monitor:
     FootprintApproach:
       type: "polygon"
       action_type: "approach"
-      footprint_topic: "/local_costmap/published_footprint"
+      footprint_topic: "local_costmap/published_footprint"
       time_before_collision: 1.2
       simulation_time_step: 0.1
       min_points: 6


### PR DESCRIPTION
## Description

Removed a leading forward slash from the `"local_costmap/published_footprint"` topic under `collision_monitor` to make it relative. 
This change resolves the warning encountered when launching the TurtleBot with a namespace:
`[collision_monitor]: [FootprintApproach]: Polygon shape is not set yet`

The issue was due to the collision monitor not finding the footprint topic when launched within a namespace.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- When launching navigation with a namespace, the warning no longer appears.
- The setup also works as expected without a namespace.
- After launching the navigation stack and setting a goal pose in RViz2 using the **2D Goal Pose**, the robot successfully navigates toward the goal without any warnings.

```bash
# Run this command
ros2 launch turtlebot4_gz_bringup turtlebot4_gz.launch.py namespace:=robot1 use_sim_time:=true
ros2 launch turtlebot4_navigation localization.launch.py namespace:=robot1 map:=<path_to_map_config_file> use_sim_time:=true
ros2 launch turtlebot4_naviagtion nav2.launch.py namespace:=robot1 use_sim_time:=true
```

## Checklist

- [x] I have performed a self-review of my own code
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation